### PR TITLE
Change consumer_id to oauth_consumer_key

### DIFF
--- a/check-login.php
+++ b/check-login.php
@@ -8,7 +8,7 @@ file_put_contents(
 
 require '../../vendor/autoload.php';
 
-$consumer = $_REQUEST['consumer_id'];
+$consumer = $_REQUEST['consumer_key'];
 $callback = $_REQUEST['callback_url'];
 
 session_id('BookAppOAuth');

--- a/identity-link-url.php
+++ b/identity-link-url.php
@@ -6,11 +6,11 @@ file_put_contents(
     FILE_APPEND
 );
 
-$consumerId = $_REQUEST['consumer_id'];
+$consumerKey = $_REQUEST['oauth_consumer_key'];
 $callbackUrl = urlencode(urldecode($_REQUEST['success_call_back']));
 
 echo <<<HTML
-<form method="post" action="check-login.php?consumer_id={$consumerId}&callback_url={$callbackUrl}">
+<form method="post" action="check-login.php?consumer_key={$consumerKey}&callback_url={$callbackUrl}">
     <p>External Book App Login</p>
     <input type="text" name="username" id="username" placeholder="Username">
     <input type="password" name="password" id="password" placeholder="Password">


### PR DESCRIPTION
Closes #2 

Changed parameter from `consumer_id` to `oauth_consumer_key` as per the updates from Magento 2.